### PR TITLE
Documentation improvements: fix citation and code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,19 +121,6 @@ u′, u = collocate_data(data, tpoints, tpoints_sample, interp, args...)
 - `u′`: Estimated derivatives
 - `u`: Smoothed data
 
-## Citation
-
-If you use SmoothedCollocation.jl in your research, please cite:
-
-```bibtex
-@article{rackauckas2020universal,
-  title={Universal differential equations for scientific machine learning},
-  author={Rackauckas, Christopher and Ma, Yingbo and Martensen, Julius and Warner, Collin and Zubov, Kirill and Supekar, Rohit and Skinner, Dominic and Ramadhan, Ali and Edelman, Alan},
-  journal={arXiv preprint arXiv:2001.04385},
-  year={2020}
-}
-```
-
 ## Contributing
 
 Contributions are welcome! Please see the [contributing guidelines](CONTRIBUTING.md) for more information.
@@ -145,7 +132,7 @@ Contributions are welcome! Please see the [contributing guidelines](CONTRIBUTING
 - [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl) - ODE solvers
 - [NoiseRobustDifferentiation.jl](https://adrianhill.de/NoiseRobustDifferentiation.jl/dev/examples/) - Specialized library for estimating derivatives from very noisy data
 
-## Cite Us
+## Citation
 
 If you use DataCollocations.jl in your research, please cite the collocation methodology paper:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,7 +56,7 @@ u0 = [2.0; 0.0]
 tspan = (0.0, 1.5)
 prob = ODEProblem(trueODEfunc, u0, tspan)
 tsteps = range(tspan[1], tspan[2]; length = 300)
-data = Array(solve(prob, Tsit5(); saveat = tsteps)) .+ 0.1*randn(2, 300)
+data = Array(solve(prob, Tsit5(); saveat = tsteps)) .+ 0.1 * randn(2, 300)
 
 # Method 1: Kernel smoothing (for noisy data)
 du, u = collocate_data(data, tsteps, EpanechnikovKernel())

--- a/docs/src/neural_ode_training.md
+++ b/docs/src/neural_ode_training.md
@@ -34,7 +34,7 @@ function trueODEfunc(du, u, p, t)
 end
 
 prob_trueode = ODEProblem(trueODEfunc, u0, tspan)
-data = Array(solve(prob_trueode, Tsit5(); saveat = tsteps)) .+ 0.1randn(2, 300)
+data = Array(solve(prob_trueode, Tsit5(); saveat = tsteps)) .+ 0.1 * randn(2, 300)
 
 du, u = collocate_data(data, tsteps, EpanechnikovKernel())
 


### PR DESCRIPTION
## Summary

This PR improves the documentation quality by fixing several issues found during a documentation review:

- **Fixed duplicate citation sections in README.md**: Removed incorrect citation referencing "SmoothedCollocation.jl" (old package name) and consolidated the citation sections
- **Fixed code formatting in examples**: Added proper spacing in multiplication expressions (`0.1randn` → `0.1 * randn`) across multiple documentation files for better readability and Julia style compliance
- **Improved consistency**: Standardized citation section naming

## Changes Made

### README.md
- Removed duplicate citation section that incorrectly referenced "SmoothedCollocation.jl"
- Consolidated citation sections under single "Citation" header
- Maintained correct citation to the Roesch et al. 2021 collocation methodology paper

### docs/src/index.md
- Fixed spacing in code example: `0.1*randn` → `0.1 * randn`

### docs/src/neural_ode_training.md
- Fixed spacing in code example: `0.1randn` → `0.1 * randn`

## Test Plan

- [x] Reviewed all documentation files for grammar and clarity
- [x] Verified code examples have consistent formatting
- [x] Ensured citation references are accurate

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)