### PR TITLE
Bump compat for OrdinaryDiffEq v7 / SciMLBase v3 ecosystem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ DataCollocationsDataInterpolationsExt = "DataInterpolations"
 ArrayInterface = "7"
 DataInterpolations = "6.4, 7, 8"
 JLArrays = "0.3"
+OrdinaryDiffEq = "6, 7"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary

- Add `OrdinaryDiffEq = "6, 7"` to `[compat]` in `Project.toml` to support the upcoming OrdinaryDiffEq v7 major release.
- No source-code migration needed: the package only uses `OrdinaryDiffEq` in tests via `ODEProblem`, `Tsit5`, and `solve`. None of the v7 breaking-change patterns from [NEWS.md](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md) (`AbstractDEAlgorithm`, `unwrapped_f`/`AutoSpecialize`, controller objects, `has_stats`/`sol.stats`, `ADTypes`) appear in the codebase.
- Part of the OrdinaryDiffEq v7 ecosystem cascade: SciML/OrdinaryDiffEq.jl#3562 (cascade 54 major bumps) and SciML/OrdinaryDiffEq.jl#3565.

## New majors covered

`OrdinaryDiffEq → 7` (OrdinaryDiffEqCore stays v4, DiffEqBase stays v7, DiffEqDevTools stays v3).

## Test plan

- [x] `Pkg.instantiate()` succeeds locally on Julia 1.10
- [x] `Pkg.test()` passes all 89 tests locally on Julia 1.10 with `OrdinaryDiffEq v6.111.0`
- [ ] CI passes with OrdinaryDiffEq v7 once released

🤖 Generated with [Claude Code](https://claude.com/claude-code)