### PR TITLE
Migrate CI to centralized SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "julia"
+    directories:
+      - "/"
+      - "/docs"
+    schedule:
+      interval: "daily"
+    groups:
+      all-julia-packages:
+        patterns:
+          - "*"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,36 +12,29 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
+  tests:
+    name: "Tests"
     strategy:
       fail-fast: false
       matrix:
         version:
-          - '1'
-          - 'lts'
-          - 'pre'
+          - "1"
+          - "lts"
+          - "pre"
         os:
           - ubuntu-latest
         arch:
           - x64
         include:
-          - version: '1.10'
+          - version: "1.10"
             os: windows-latest
             arch: x64
-          - version: '1.10'
+          - version: "1.10"
             os: macOS-latest
             arch: x64
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
-        with:
-          files: lcov.info
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      julia-arch: "${{ matrix.arch }}"
+      os: "${{ matrix.os }}"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,9 +1,8 @@
-name: Documentation
+name: Downgrade
 
 on:
   push:
     branches: [main]
-    tags: ["*"]
   pull_request:
 
 concurrency:
@@ -13,8 +12,9 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
-  build:
-    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+  downgrade:
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      coverage: false
+      julia-version: "lts"
+      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,9 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,8 @@
+name: Spell Check
+
+on: [pull_request]
+
+jobs:
+  typos-check:
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,31 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

Normalizes CI to the SciML standard set, implemented via the centralized reusable workflows in [`SciML/.github`](https://github.com/SciML/.github) (every caller pinned `@v1`, `secrets: "inherit"`).

## Workflows converted
- **CI.yml** → `tests.yml@v1` caller. Reproduces the exact original matrix: `ubuntu-latest` x `x64` x `{1, lts, pre}`, plus `include` entries `windows-latest`/`macOS-latest` x `1.10`. Coverage left enabled (default) to match the original codecov step.
- **documentation.yml** → `documentation.yml@v1` caller. `coverage: false` because the original docs workflow did not collect/upload coverage.
- **FormatCheck.yml** → `runic.yml@v1` caller. The repo already ran Runic via `fredrikekre/runic-action`; the tree is Runic-clean (verified locally, `Runic.main(["--check","."])` exit 0), so no reformatting was applied.

## Workflows added
- **SpellCheck.yml** → `spellcheck.yml@v1` caller. `typos` reports no findings locally.
- **Downgrade.yml** → `downgrade.yml@v1` caller (`julia-version: lts`, `skip: "Pkg,TOML"`). None existed before.
- **TagBot.yml** → standard `JuliaRegistries/TagBot@v1` setup (DataCollocations is a registered package; none existed before).

## Dependency automation
- Added **.github/dependabot.yml** with a `github-actions` block (`/`, weekly) and a `julia` block (dirs `/` and `/docs` — the directories that actually contain a `Project.toml`; daily; grouped `all-julia-packages: ["*"]`).
- **CompatHelper**: none present, nothing to remove.

## Typos findings
None.

## Notes / caveats
- **Branch protection**: check names change (e.g. the tests job is now `Tests`, the Runic job `Runic Format Check`, spellcheck `Spell Check with Typos`). Required-status-checks in branch protection must be updated accordingly, or merges may block on stale required checks.
- The old `documentation.yml` had a custom trailing **doctest** step that referenced module `SmoothedCollocation` (not `DataCollocations`) — a stale/incorrect reference that would have failed if reached. The centralized `documentation.yml@v1` builds via `docs/make.jl` and does not run that separate doctest block, so this stale step is dropped. If doctests are desired, they should be wired into `docs/make.jl` against `DataCollocations`.
- No downstream/IntegrationTest, benchmark, or QA workflow existed, so none were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
