### PR TITLE
Canonicalize test units to @safetestset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ Documenter = "1"
 JLArrays = "0.3"
 OrdinaryDiffEq = "6, 7"
 Plots = "1"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"
 
@@ -31,8 +32,9 @@ JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 docs = ["Documenter", "DataInterpolations", "OrdinaryDiffEq", "Plots"]
-test = ["DataInterpolations", "JET", "JLArrays", "OrdinaryDiffEq", "Pkg", "Test"]
+test = ["DataInterpolations", "JET", "JLArrays", "OrdinaryDiffEq", "Pkg", "SafeTestsets", "Test"]

--- a/test/kernels_setup.jl
+++ b/test/kernels_setup.jl
@@ -1,0 +1,10 @@
+using DataCollocations
+
+bounded_support_kernels = [
+    EpanechnikovKernel(), UniformKernel(), TriangularKernel(),
+    QuarticKernel(), TriweightKernel(), TricubeKernel(), CosineKernel(),
+]
+
+unbounded_support_kernels = [
+    GaussianKernel(), LogisticKernel(), SigmoidKernel(), SilvermanKernel(),
+]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 DataCollocations = "9454e98c-75cb-4dbc-9573-481819719962"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -8,5 +9,6 @@ DataCollocations = {path = "../.."}
 
 [compat]
 JET = "0.9, 0.10"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/jet_tests.jl
+++ b/test/qa/jet_tests.jl
@@ -1,0 +1,23 @@
+using DataCollocations
+using Test
+using JET
+
+# Test kernel functions for type stability
+@testset "calckernel optimization" begin
+    kernels = [
+        EpanechnikovKernel(), UniformKernel(), TriangularKernel(),
+        QuarticKernel(), TriweightKernel(), TricubeKernel(),
+        GaussianKernel(), CosineKernel(), LogisticKernel(),
+        SigmoidKernel(), SilvermanKernel(),
+    ]
+    @testset "$kernel" for kernel in kernels
+        JET.@test_opt target_modules = (DataCollocations,) DataCollocations.calckernel(kernel, 0.5)
+    end
+end
+
+# Test main collocate_data function
+@testset "collocate_data optimization" begin
+    data = rand(2, 20)
+    tpoints = collect(range(0.0, 1.0, length = 20))
+    JET.@test_opt target_modules = (DataCollocations,) collocate_data(data, tpoints, TriangularKernel(), 0.1)
+end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,25 +1,5 @@
-using DataCollocations
-using Test
-using JET
+using SafeTestsets
 
-@testset "JET Static Analysis" begin
-    # Test kernel functions for type stability
-    @testset "calckernel optimization" begin
-        kernels = [
-            EpanechnikovKernel(), UniformKernel(), TriangularKernel(),
-            QuarticKernel(), TriweightKernel(), TricubeKernel(),
-            GaussianKernel(), CosineKernel(), LogisticKernel(),
-            SigmoidKernel(), SilvermanKernel(),
-        ]
-        @testset "$kernel" for kernel in kernels
-            JET.@test_opt target_modules = (DataCollocations,) DataCollocations.calckernel(kernel, 0.5)
-        end
-    end
-
-    # Test main collocate_data function
-    @testset "collocate_data optimization" begin
-        data = rand(2, 20)
-        tpoints = collect(range(0.0, 1.0, length = 20))
-        JET.@test_opt target_modules = (DataCollocations,) collocate_data(data, tpoints, TriangularKernel(), 0.1)
-    end
+@safetestset "JET Static Analysis" begin
+    include("jet_tests.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,6 @@
 using Pkg
-using DataCollocations
+using SafeTestsets
 using Test
-using OrdinaryDiffEq
-using DataInterpolations
-using JLArrays
 
 const GROUP = get(ENV, "GROUP", "All")
 
@@ -14,16 +11,11 @@ if GROUP == "QA"
     include(joinpath(@__DIR__, "qa", "qa.jl"))
 else
     @testset "DataCollocations.jl" begin
-        bounded_support_kernels = [
-            EpanechnikovKernel(), UniformKernel(), TriangularKernel(),
-            QuarticKernel(), TriweightKernel(), TricubeKernel(), CosineKernel(),
-        ]
+        @safetestset "Kernel Functions" begin
+            using DataCollocations
+            using Test
+            include("kernels_setup.jl")
 
-        unbounded_support_kernels = [
-            GaussianKernel(), LogisticKernel(), SigmoidKernel(), SilvermanKernel(),
-        ]
-
-        @testset "Kernel Functions" begin
             ts = collect(-5.0:0.1:5.0)
             @testset "Kernels with support from -1 to 1" begin
                 minus_one_index = findfirst(x -> ==(x, -1.0), ts)
@@ -54,7 +46,12 @@ else
             end
         end
 
-        @testset "Collocation of data" begin
+        @safetestset "Collocation of data" begin
+            using DataCollocations
+            using OrdinaryDiffEq
+            using Test
+            include("kernels_setup.jl")
+
             f(u, p, t) = p .* u
             rc = 2
             ps = repeat([-0.001], rc)
@@ -75,7 +72,11 @@ else
             end
         end
 
-        @testset "DataInterpolations Extension" begin
+        @safetestset "DataInterpolations Extension" begin
+            using DataCollocations
+            using DataInterpolations
+            using Test
+
             # Test with simple data
             t = 0.0:0.1:1.0
             data = sin.(t)
@@ -87,7 +88,11 @@ else
             @test length(u) == length(tpoints_sample)
         end
 
-        @testset "Interface Compatibility" begin
+        @safetestset "Interface Compatibility" begin
+            using DataCollocations
+            using JLArrays
+            using Test
+
             @testset "BigFloat support" begin
                 # Test that BigFloat inputs are supported and eltype is preserved
                 tpoints = BigFloat.(collect(range(0.0, stop = 10.0, length = 30)))


### PR DESCRIPTION
## Summary

Wraps each independent test unit in `@safetestset` so it runs in its own module, giving isolation between units and world-age safety, matching the canonical OrdinaryDiffEq test structure.

### Changes
- **`test/runtests.jl`**: the four units inside the `"DataCollocations.jl"` testset (Kernel Functions, Collocation of data, DataInterpolations Extension, Interface Compatibility) become `@safetestset` blocks, each carrying its own imports. The shared bounded/unbounded kernel lists move to a small `test/kernels_setup.jl` that the two units depending on them `include`.
- **`test/qa/qa.jl`**: the JET unit becomes `@safetestset`; its body is extracted to `test/qa/jet_tests.jl` and `include`d (so `using JET` runs before `JET.@test_opt` is reached, avoiding the macro-not-yet-defined macroexpand gotcha).
- Added `SafeTestsets` to the test deps (root `[extras]`/`[targets]` and `test/qa/Project.toml`) with compat `"0.1, 1"`.

The `GROUP` dispatch, the set of tests that run, and all assertions are unchanged. Behavior-preserving: only unit wrapping + self-containment.

### Verification
Ran locally with Julia 1.11:
- `GROUP=Core`: `DataCollocations.jl` 77/77 pass.
- `GROUP=QA`: `JET Static Analysis` 12/12 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ignore until reviewed by @ChrisRackauckas.