### PR TITLE
QA: allow JET 0.11 so QA runs on Julia 1.12

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -9,7 +9,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 DataCollocations = {path = "../.."}
 
 [compat]
-JET = "0.9, 0.10"
+JET = "0.9, 0.10, 0.11"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "1"
 Test = "1"


### PR DESCRIPTION
## Problem

The `tests / QA (julia 1, ubuntu-latest)` check on `main` is red. On Julia 1.12.6 the QA sub-env (`test/qa/Project.toml`) pins `JET = "0.9, 0.10"`, so the resolver selects **JET v0.10.14**, which fails to precompile:

```
ERROR: LoadError: MethodError: no method matching add_active_gotos!(::BitVector, ::Core.CodeInfo, ::Compiler.CFG, ::Compiler.GenericDomTree{true})
  add_active_gotos!(::Any, ::Core.CodeInfo, ::Compiler.CFG, ::Any, ::LoweredCodeUtils.SelectiveEvalController)
```

This is a JET 0.10.x / LoweredCodeUtils signature mismatch against the Julia 1.12 compiler internals. JET **0.11** is the line that supports Julia 1.12.

## Fix

Widen the QA sub-env compat to `JET = "0.9, 0.10, 0.11"`. The resolver then picks a JET that works for each Julia in the QA matrix:
- Julia 1.12 (`"1"`) → JET 0.11.4
- Julia 1.10 (`"lts"`) → JET 0.9.18 (JET 0.11 requires julia ≥ 1.12)

No test was skipped, disabled, or loosened.

## Local verification

Reproduced and verified with `julia +1.12` / `julia +1.10` on the QA sub-env.

Before (current `0.9, 0.10`), Julia 1.12.6:
```
JET resolved to: 0.10.14
Failed to precompile JET ... MethodError: no method matching add_active_gotos!(...)
```

After (`0.9, 0.10, 0.11`):
```
# Julia 1.12.6
JET resolved to: 0.11.4
Test Summary:       | Pass  Total  Time
JET Static Analysis |   12     12  4.3s

# Julia 1.10.11 (LTS)
JET resolved to: 0.9.18
Test Summary:       | Pass  Total  Time
JET Static Analysis |   12     12  4.0s
```

## Note

This PR fixes the QA check only. The Documentation build is also red, but for an unrelated, genuine doc-content reason: the `docs/src/neural_ode_training.md` example does `using DiffEqFlux` and `using DataCollocations`, both of which export `collocate_data`, so the unqualified call hits `UndefVarError: collocate_data not defined` (binding ambiguity). That is a separate doc fix (qualify the name) and is intentionally not bundled here.

Please ignore until reviewed by @ChrisRackauckas.
